### PR TITLE
优化调度器实时数据入库失败的debug流程

### DIFF
--- a/get_source_realtime_data.py
+++ b/get_source_realtime_data.py
@@ -5,27 +5,30 @@ import time
 # 初始化后台调度器
 scheduler = BackgroundScheduler(timezone='UTC')
 
-# 每周周日23时0分0秒到周一13时0分0秒,只更新mt5相关数据
+#待跳过拉取的symbol name 
+skip_symbols = ['TNX']
+
+# 每周周日23时0分0秒到周一13时0分0秒,只更新非TNX以外的数据
 #周日
 # 分钟级数据
 scheduler.add_job(
-    fetcher.update_realtime_data_mt5_only,
+    fetcher.update_realtime_data,
     trigger='cron',
     day_of_week='sun',
     hour='23',
     minute='0-59',
-    args=['1m'],
+    args=['1m', skip_symbols],
     max_instances=100,
     misfire_grace_time=60,
     coalesce=True
 )
 # 小时级数据
 scheduler.add_job(
-    fetcher.update_realtime_data_mt5_only,
+    fetcher.update_realtime_data,
     trigger='cron',
     day_of_week='sun',
     hour='23',
-    args=['1h'],
+    args=['1h', skip_symbols],
     max_instances=100,
     misfire_grace_time=60,
     coalesce=True
@@ -34,23 +37,23 @@ scheduler.add_job(
 #周一
 # 分钟级数据
 scheduler.add_job(
-    fetcher.update_realtime_data_mt5_only,
+    fetcher.update_realtime_data,
     trigger='cron',
     day_of_week='mon',
     hour='0-13',
     minute='0-59',
-    args=['1m'],
+    args=['1m', skip_symbols],
     max_instances=100,
     misfire_grace_time=60,
     coalesce=True
 )
 #小时级数据
 scheduler.add_job(
-    fetcher.update_realtime_data_mt5_only,
+    fetcher.update_realtime_data,
     trigger='cron',
     day_of_week='mon',
     hour='0-13',
-    args=['1h'],
+    args=['1h', skip_symbols],
     max_instances=100,
     misfire_grace_time=60,
     coalesce=True
@@ -113,23 +116,23 @@ scheduler.add_job(
 # 周六0点-周六3点,只更新mt5的数据
 # 分钟级数据
 scheduler.add_job(
-    fetcher.update_realtime_data_mt5_only,
+    fetcher.update_realtime_data,
     trigger='cron',
     day_of_week='sat',
     hour='0-3',
     minute='0-59',
-    args=['1m'],
+    args=['1m', skip_symbols],
     max_instances=100,
     misfire_grace_time=60,
     coalesce=True
 )
 # 小时级数据
 scheduler.add_job(
-    fetcher.update_realtime_data_mt5_only,
+    fetcher.update_realtime_data,
     trigger='cron',
     day_of_week='sat',
     hour='0-3',
-    args=['1h'],
+    args=['1h', skip_symbols],
     max_instances=100,
     misfire_grace_time=60,
     coalesce=True

--- a/get_source_realtime_data.py
+++ b/get_source_realtime_data.py
@@ -3,14 +3,13 @@ from apscheduler.schedulers.background import BackgroundScheduler
 import time
 
 # 初始化后台调度器
-scheduler = BackgroundScheduler(timezone='Asia/Shanghai')
+scheduler = BackgroundScheduler(timezone='UTC')
 
-# 添加调度器任务
-# 每周周日23时0分0秒-周六凌晨2点，始执行实时更新method list中所有symbol的入库任务
-# 周日23点-周日0点
+# 每周周日23时0分0秒到周一13时0分0秒,只更新mt5相关数据
+#周日
 # 分钟级数据
 scheduler.add_job(
-    fetcher.update_realtime_data,
+    fetcher.update_realtime_data_mt5_only,
     trigger='cron',
     day_of_week='sun',
     hour='23',
@@ -22,7 +21,7 @@ scheduler.add_job(
 )
 # 小时级数据
 scheduler.add_job(
-    fetcher.update_realtime_data,
+    fetcher.update_realtime_data_mt5_only,
     trigger='cron',
     day_of_week='sun',
     hour='23',
@@ -32,12 +31,65 @@ scheduler.add_job(
     coalesce=True
 )
 
-# 周一0点～周五23点
+#周一
+# 分钟级数据
+scheduler.add_job(
+    fetcher.update_realtime_data_mt5_only,
+    trigger='cron',
+    day_of_week='mon',
+    hour='0-13',
+    minute='0-59',
+    args=['1m'],
+    max_instances=100,
+    misfire_grace_time=60,
+    coalesce=True
+)
+#小时级数据
+scheduler.add_job(
+    fetcher.update_realtime_data_mt5_only,
+    trigger='cron',
+    day_of_week='mon',
+    hour='0-13',
+    args=['1h'],
+    max_instances=100,
+    misfire_grace_time=60,
+    coalesce=True
+)
+
+
+# 周一13点～周五23点,同时更新yfinance和mt5的数据
+#周一13点～周一23点
 # 分钟级数据
 scheduler.add_job(
     fetcher.update_realtime_data,
     trigger='cron',
-    day_of_week='mon-fri',
+    day_of_week='mon',
+    hour='13-23',
+    minute='0-59',
+    args=['1m'],
+    max_instances=100,
+    misfire_grace_time=60,
+    coalesce=True
+    )
+# 小时级数据
+scheduler.add_job(
+    fetcher.update_realtime_data,
+    trigger='cron',
+    day_of_week='mon',
+    hour='13-23',
+    args=['1h'],
+    max_instances=100,
+    misfire_grace_time=60,
+    coalesce=True
+    )
+
+
+#周二0点～周五23点
+# 分钟级数据
+scheduler.add_job(
+    fetcher.update_realtime_data,
+    trigger='cron',
+    day_of_week='tue-fri',
     hour='0-23',
     minute='0-59',
     args=['1m'],
@@ -50,7 +102,7 @@ scheduler.add_job(
 scheduler.add_job(
     fetcher.update_realtime_data,
     trigger='cron',
-    day_of_week='mon-fri',
+    day_of_week='tue-fri',
     hour='0-23',
     args=['1h'],
     max_instances=100,
@@ -58,13 +110,13 @@ scheduler.add_job(
     coalesce=True
 )
 
-# 周六0点-周六3点
+# 周六0点-周六3点,只更新mt5的数据
 # 分钟级数据
 scheduler.add_job(
-    fetcher.update_realtime_data,
+    fetcher.update_realtime_data_mt5_only,
     trigger='cron',
     day_of_week='sat',
-    hour='0-9',
+    hour='0-3',
     minute='0-59',
     args=['1m'],
     max_instances=100,
@@ -73,10 +125,10 @@ scheduler.add_job(
 )
 # 小时级数据
 scheduler.add_job(
-    fetcher.update_realtime_data,
+    fetcher.update_realtime_data_mt5_only,
     trigger='cron',
     day_of_week='sat',
-    hour='0-9',
+    hour='0-3',
     args=['1h'],
     max_instances=100,
     misfire_grace_time=60,

--- a/libs/commons.py
+++ b/libs/commons.py
@@ -20,7 +20,7 @@ def create_logger(name='app'):
         logger.setLevel(logging.INFO)
         log_map[name] = logger
         # 输出到日志文件
-        handler = logging.FileHandler(name+".txt")
+        handler = logging.FileHandler('logs/'+name+datetime.now().strftime('%Y-%m-%d')+".txt")
         handler.setLevel(logging.INFO)
         handler.setFormatter(logging.Formatter(LOG_FORMAT))
         logger.addHandler(handler)

--- a/libs/commons.py
+++ b/libs/commons.py
@@ -1,4 +1,5 @@
 import logging
+import logging.config
 
 import mysql.connector
 from configparser import ConfigParser
@@ -19,8 +20,9 @@ def create_logger(name='app'):
         logger = logging.getLogger(name)
         logger.setLevel(logging.INFO)
         log_map[name] = logger
-        # 输出到日志文件
-        handler = logging.FileHandler('logs/'+name+datetime.now().strftime('%Y-%m-%d')+".txt")
+        # 输出到日志文件,按天分文件，保存30天
+        handler = logging.handlers.TimedRotatingFileHandler('logs/'+name+'_today.log', 'D', 1 , 30)
+        handler.suffix = "%Y-%m-%d.log"
         handler.setLevel(logging.INFO)
         handler.setFormatter(logging.Formatter(LOG_FORMAT))
         logger.addHandler(handler)

--- a/libs/fetcher.py
+++ b/libs/fetcher.py
@@ -80,113 +80,9 @@ def get_historical_data_from_mt5(symbol, interval, start, end):
     mt5.shutdown()
     return rates_list
 
-#单独封装mt5的实时入库函数
-def update_realtime_data_mt5_only(interval):
-    # 初始化数据库连接
-    symbols = Symbol.select()
-    # 结果列表
-    result_list = []
-    # 获取symbol method对应的method list，并进行遍历
-    for symbol in symbols:
-        symbol_name = symbol.name
-        # 根据symbol name获取拉取数据用的symbol value，用于获取数据
-        symbol_value = symbol.symbol_value
-        method = symbol.method
-        timezone = symbol.timezone
-        yf_rates = []
-        mt5_rates = []
-        dxy_rates = []
-        # 用于保存每种计算方式的字典
-        data_dict = dict(symbol=symbol_value, interval=interval, timezone=timezone, method=method)
-        # 拉取yfinance数据源的symbol数据
-        if method == 'get_historical_data_from_yfinance':
-            # 由于此处仅拉取mt5相关数据，所以yf_rates直接置为空值以保持结果格式的一致
-            yf_rates.append(dict(symbol=symbol_value, interval=interval, ts=0,
-                                 price_open=0.0, price_high=0.0,
-                                 price_low=0.0, price_closed=0.0)
-                    )
-            # 附加到data_dict中
-            data_dict['value'] = yf_rates
-            result_list.append(data_dict)
-
-        # 拉取mt5数据的symbol数据
-        elif method == 'get_historical_data_from_mt5':
-            # 分钟级的逻辑
-            if interval == '1m':
-                # 生成转换为mt5时区后的时间间隔并去掉秒，开始时间为上一分钟
-                mt5_tz = pytz.timezone(timezone)
-                current_time = datetime.now(tz=mt5_tz).strftime('%Y-%m-%d %H:%M')
-                mt5_start_time = pd.to_datetime(current_time) - timedelta(minutes=1)
-                # 结束时间等于开始时间
-                mt5_end_time = mt5_start_time
-                # 拉取数据
-                try:
-                    mt5_rates.append(
-                        get_historical_data_from_mt5(symbol_value, interval, mt5_start_time, mt5_end_time)[0])
-                    # 附加到data_dict中
-                    data_dict['value'] = mt5_rates
-                    # 数据入库
-                    batch_save_by_symbol(symbol_value, mt5_rates)
-                except IndexError:
-                    logger.error("%s:数据拉取失败@%s", symbol_value, str(mt5_start_time) + "~" + str(mt5_end_time))
-            # 小时级的逻辑
-            if interval == '1h':
-                # 生成转换为mt5时区后的时间间隔并去掉秒和分钟，开始时间为上一小时
-                mt5_tz = pytz.timezone(timezone)
-                current_time = datetime.now(tz=mt5_tz).strftime('%Y-%m-%d %H')
-                # 开始时间为上一个小时
-                mt5_start_time = pd.to_datetime(current_time) - timedelta(hours=1)
-                # 结束时间等于开始时间
-                mt5_end_time = mt5_start_time
-                # 拉取数据
-                try:
-                    mt5_rates.append(
-                        get_historical_data_from_mt5(symbol_value, interval, mt5_start_time, mt5_end_time)[0])
-                    # 附加到data_dict中
-                    data_dict['value'] = mt5_rates
-                    # 数据入库
-                    batch_save_by_symbol(symbol_value, mt5_rates)
-                except IndexError:
-                    logger.error("%s:数据拉取失败@%s", symbol_value, str(mt5_start_time) + "~" + str(mt5_start_time))
-            result_list.append(data_dict)
-        # 从mt5拉取数据去生成的symbol数据,当前只有dxy，如果有需要就继续在此分支下添加if即可
-        if method == 'originate_from_mt5':
-            # 根据mt5等货币对报价，生成DXY
-            if symbol_value == 'DXY_MT5':
-                # 分钟级的逻辑
-                if interval == '1m':
-                    # 生成转换为mt5时区后的时间间隔并去掉秒，开始时间为上一分钟
-                    mt5_tz = pytz.timezone(timezone)
-                    current_time = datetime.now(tz=mt5_tz).strftime('%Y-%m-%d %H:%M')
-                    mt5_start_time = pd.to_datetime(current_time) - timedelta(minutes=1)
-                    # 结束时间与开始时间相等
-                    mt5_end_time = mt5_start_time
-                # 小时级的逻辑
-                if interval == '1h':
-                    # 生成转换为mt5时区后的时间间隔并去掉秒和分钟，开始时间为上一小时
-                    mt5_tz = pytz.timezone(timezone)
-                    current_time = datetime.now(tz=mt5_tz).strftime('%Y-%m-%d %H')
-                    # 开始时间为上一个小时
-                    mt5_start_time = pd.to_datetime(current_time) - timedelta(hours=1)
-                    # 结束时间与开始时间相等
-                    mt5_end_time = mt5_start_time
-                # 拉取并计算dxy
-                try:
-                    dxy_rates = get_dxy_from_mt5(mt5_start_time, mt5_end_time, interval)
-                except IndexError:
-                    logger.error("%s:数据拉取失败@%s", symbol_value, str(mt5_start_time) + "~" + str(mt5_end_time))
-                else:
-                    # 附加到data_dict中
-                    data_dict['value'] = dxy_rates
-                    # 数据入库
-                    batch_save_by_symbol(symbol_value, dxy_rates)
-            result_list.append(data_dict)
-    # print(datetime.now(), result_list)
-    logger.info("%s", result_list)
-    return result_list
 
 # 封装入库实时数据schedule函数
-def update_realtime_data(interval):
+def update_realtime_data(interval, skip_symbol = None):
     # 初始化数据库连接
     symbols = Symbol.select()
     # 结果列表
@@ -201,13 +97,17 @@ def update_realtime_data(interval):
         yf_rates = []
         mt5_rates = []
         dxy_rates = []
+        #如果遇到需要跳过的symbol，则直接跳过此symbol的拉取
+        if symbol_name in skip_symbol:
+            continue
         # 用于保存每种计算方式的字典
         data_dict = dict(symbol=symbol_value, interval=interval, timezone=timezone, method=method)
         # 拉取yfinance数据源的symbol数据
         if method == 'get_historical_data_from_yfinance':
             # 生成时间间隔，必需按照时区转换时间后，按照隔日进行拉取
+            #实时数据拉取的start和end必须只传到日为止，比如2022-03-21，不能在后面带时分秒，否则会报错
             yf_tz = pytz.timezone(timezone)
-            yf_start_time = yf_tz.localize(datetime.now())
+            yf_start_time = yf_tz.localize(datetime.now()).date()
             yf_end_time = yf_start_time + timedelta(days=1)
             # yfinance的分钟级及小时级数据拉取逻辑一致
             # 拉取数据，并截取最后一个元素作为结果

--- a/libs/fetcher.py
+++ b/libs/fetcher.py
@@ -82,7 +82,7 @@ def get_historical_data_from_mt5(symbol, interval, start, end):
 
 
 # 封装入库实时数据schedule函数
-def update_realtime_data(interval, skip_symbol = None):
+def update_realtime_data(interval, skip_symbol = []):
     # 初始化数据库连接
     symbols = Symbol.select()
     # 结果列表

--- a/libs/fetcher.py
+++ b/libs/fetcher.py
@@ -107,7 +107,7 @@ def update_realtime_data(interval, skip_symbol = []):
             # 生成时间间隔，必需按照时区转换时间后，按照隔日进行拉取
             #实时数据拉取的start和end必须只传到日为止，比如2022-03-21，不能在后面带时分秒，否则会报错
             yf_tz = pytz.timezone(timezone)
-            yf_start_time = yf_tz.localize(datetime.now()).date()
+            yf_start_time = datetime.now(tz=yf_tz).date()
             yf_end_time = yf_start_time + timedelta(days=1)
             # yfinance的分钟级及小时级数据拉取逻辑一致
             # 拉取数据，并截取最后一个元素作为结果


### PR DESCRIPTION

    1. 需求链接
    https://trello.com/c/SPweoT0X
    2. 由于没有找到可以满足指定调度需求的库，所以还是继续使用apscheduler，只是将mt5_only和mt5+yfinance的拉取数据函数进行了分离，希望可以减少出错的机会
    3. logger_create默认按照日期分文件，方便定位日志；默认存放在logs目录下