### PR TITLE
在默认的日志文件名中增加进程ID进行区分，避免每周补录任务和实时任务的日志文件有冲突

### DIFF
--- a/libs/commons.py
+++ b/libs/commons.py
@@ -4,6 +4,7 @@ import logging.config
 import mysql.connector
 from configparser import ConfigParser
 from datetime import datetime
+import os
 
 import pytz
 
@@ -20,7 +21,7 @@ def create_logger(name='app'):
         logger.setLevel(logging.INFO)
         log_map[name] = logger
         # 输出到日志文件,按天分文件，保存30天
-        handler = logging.handlers.TimedRotatingFileHandler('logs/' + name + '.log', 'D', 1, 30)
+        handler = logging.handlers.TimedRotatingFileHandler('logs/' + name + '.' + str(os.getpid()) + '.log', 'D', 1, 30)
         handler.suffix = "%Y-%m-%d.log"
         handler.setLevel(logging.INFO)
         handler.setFormatter(logging.Formatter(LOG_FORMAT))

--- a/test_case/test_new_logger.py
+++ b/test_case/test_new_logger.py
@@ -1,0 +1,5 @@
+import sys
+sys.path.append('..')
+from libs import commons
+
+commons.create_logger('test')

--- a/test_case/test_new_logger.py
+++ b/test_case/test_new_logger.py
@@ -1,5 +1,0 @@
-import sys
-sys.path.append('..')
-from libs import commons
-
-commons.create_logger('test')


### PR DESCRIPTION
在默认的日志文件名中增加进程ID进行区分，避免每周补录任务和实时任务的日志文件有冲突